### PR TITLE
Support for the sorters parameter

### DIFF
--- a/inst/htmlwidgets/rpivotTable.js
+++ b/inst/htmlwidgets/rpivotTable.js
@@ -21,7 +21,12 @@ HTMLWidgets.widget({
         $.pivotUtilities.d3_renderers,
         $.pivotUtilities.c3_renderers
       );
-
+      
+      if (typeof x.params.sorters != "undefined") {
+        if (typeof x.params.sorters[0] == "string") {
+          x.params.sorters = eval("("+x.params.sorters[0]+")")
+        }
+      }
 
       $('#'+el.id).pivotUI(
       		x.data, x.params


### PR DESCRIPTION
I wanted to pass to rpivotTable the sorters parameter to define my own sorting function on a column, but rpivotTable crashes with an error message.
With this modification this attribute get's correctly passed on to pivottable.js